### PR TITLE
Recognize foldable @group from CSSEdit

### DIFF
--- a/Syntaxes/CSS.plist
+++ b/Syntaxes/CSS.plist
@@ -12,7 +12,7 @@
 	<key>foldingStartMarker</key>
 	<string>/\*\*(?!\*)|\{\s*($|/\*(?!.*?\*/.*\S))|\/\*\s*@group\s*.*\s*\*\/</string>
 	<key>foldingStopMarker</key>
-	<string>(?<!\*)\*\*/|^\s*\}|\/*\s*@end\s*\*\/</string>
+	<string>(?&lt;!\*)\*\*/|^\s*\}|\/*\s*@end\s*\*\/</string>
 	<key>keyEquivalent</key>
 	<string>^~C</string>
 	<key>name</key>


### PR DESCRIPTION
I use both Textmate and CSSEdit to edit CSS files. CSSEdit has a nice @group feature to fold blocks of CSS. This patch lets Textmate fold those too. [Regexps from css-tricks.com.](http://css-tricks.com/forums/discussion/2783/foldable-textmate-css-groups-i.e.-cssedit/p1)
