### PR TITLE
Closing } do not have correct scope.

### DIFF
--- a/Syntaxes/CSS.plist
+++ b/Syntaxes/CSS.plist
@@ -250,7 +250,7 @@
 			<key>begin</key>
 			<string>(?=\{)</string>
 			<key>end</key>
-			<string>\}</string>
+			<string>(\})</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
I may be wrong but when using the Solorized theme I noticed that opening and closing {} were not highlighted the same. This of course may be intentional but it annoyed me and in the process of figuring out how to change it I discovered that closing } do not have a scope applied to them - thus they are highlighted as an invalid character.

Adding the ( ) around the 'end' regex seems to allow the endCaptures to capture the } and apply the punctuation.section.property-list.css scope correctly and now both { and } and sytax highlighted the same way.
