### PR TITLE
Fix `meta.selector.css` to not extend outside the style block if embedded

### DIFF
--- a/Syntaxes/CSS.plist
+++ b/Syntaxes/CSS.plist
@@ -741,7 +741,7 @@
 			<key>begin</key>
 			<string>\s*(?=[:.*#a-zA-Z])</string>
 			<key>end</key>
-			<string>(?=[/@{)])</string>
+			<string>(?=[/@{)]|```|&lt;\/style&gt;)</string>
 			<key>name</key>
 			<string>meta.selector.css</string>
 			<key>patterns</key>


### PR DESCRIPTION
Affects embedded CSS (e.g. in HTML or in a Markdown variant supporting code blocks with syntax highlighting) only:

While typing a selector, the pattern for `meta.selector.css` would swallow up everything from the cursor until the end of the document - extending beyond the end of the embedded CSS block and thus destroying syntax highlighting for the rest of the document.

<img width="394" alt="bildschirmfoto 2017-03-17 um 00 03 04" src="https://cloud.githubusercontent.com/assets/244158/24022397/7e7c963e-0aa6-11e7-9a2d-6a29cd83ad60.png">
<img width="357" alt="bildschirmfoto 2017-03-17 um 00 04 25" src="https://cloud.githubusercontent.com/assets/244158/24022401/83716642-0aa6-11e7-9c07-0bd440735c74.png">
