### PR TITLE
Copy latest CSS grammar from VSCode

### DIFF
--- a/Syntaxes/CSS.plist
+++ b/Syntaxes/CSS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>uuid</key>
-	<string>76f38571-e451-4c1e-9c12-99a77df1eb88</string>
+	<string>69AA0917-B7BB-11D9-A7E2-000D93C8BE28</string>
 	<key>fileTypes</key>
 	<array>
 		<string>css</string>

--- a/Syntaxes/CSS.plist
+++ b/Syntaxes/CSS.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>uuid</key>
+	<string>76f38571-e451-4c1e-9c12-99a77df1eb88</string>
 	<key>fileTypes</key>
 	<array>
 		<string>css</string>
@@ -9,8 +11,18 @@
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~C</string>
+	<key>information_for_contributors</key>
+	<array>
+		<string>This file has been converted from https://github.com/atom/language-css/blob/master/grammars/css.cson</string>
+		<string>If you want to provide a fix or improvement, please create a pull request against the original repository.</string>
+		<string>Once accepted there, we are happy to receive an update request.</string>
+	</array>
 	<key>name</key>
 	<string>CSS</string>
+	<key>scopeName</key>
+	<string>source.css</string>
+	<key>version</key>
+	<string>https://github.com/atom/language-css/commit/672168274c7b457f3c118788b5171ae888c1bf07</string>
 	<key>patterns</key>
 	<array>
 		<dict>
@@ -19,190 +31,212 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#escapes</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#combinators</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#selector</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>\s*((@)charset\b)\s*</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.at-rule.charset.css</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.keyword.css</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\s*((?=;|$))</string>
-			<key>name</key>
-			<string>meta.at-rule.charset.css</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#string-double</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single</string>
-				</dict>
-			</array>
+			<key>include</key>
+			<string>#at-rules</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>\s*((@)import\b)\s*</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.at-rule.import.css</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.keyword.css</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\s*((?=;|\}))</string>
-			<key>name</key>
-			<string>meta.at-rule.import.css</string>
+			<key>include</key>
+			<string>#rule-list</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>at-rules</key>
+		<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>include</key>
-					<string>#string-double</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single</string>
-				</dict>
-				<dict>
 					<key>begin</key>
-					<string>\s*(url)\s*(\()\s*</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.url.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
+					<string>\A(?:\xEF\xBB\xBF)?(?i:(?=\s*@charset\b))</string>
 					<key>end</key>
-					<string>\s*(\))\s*</string>
+					<string>;|(?=$)</string>
 					<key>endCaptures</key>
 					<dict>
-						<key>1</key>
+						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.function.css</string>
+							<string>punctuation.terminator.rule.css</string>
 						</dict>
 					</dict>
+					<key>name</key>
+					<string>meta.at-rule.charset.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.not-lowercase.charset.css</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.leading-whitespace.charset.css</string>
+								</dict>
+								<key>3</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.no-whitespace.charset.css</string>
+								</dict>
+								<key>4</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.whitespace.charset.css</string>
+								</dict>
+								<key>5</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.not-double-quoted.charset.css</string>
+								</dict>
+								<key>6</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.unclosed-string.charset.css</string>
+								</dict>
+								<key>7</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.unexpected-characters.charset.css</string>
+								</dict>
+							</dict>
 							<key>match</key>
-							<string>[^'") \t]+</string>
+							<string>(?x)        # Possible errors:
+\G
+((?!@charset)@\w+)   # Not lowercase (@charset is case-sensitive)
+|
+\G(\s+)             # Preceding whitespace
+|
+(@charset\S[^;]*)    # No whitespace after @charset
+|
+(?&lt;=@charset)         # Before quoted charset name
+(\x20{2,}|\t+)      # More than one space used, or a tab
+|
+(?&lt;=@charset\x20)    # Beginning of charset name
+([^&quot;;]+)              # Not double-quoted
+|
+(&quot;[^&quot;]+$)             # Unclosed quote
+|
+(?&lt;=&quot;)                # After charset name
+([^;]+)               # Unexpected junk instead of semicolon</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.charset.css</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>((@)charset)(?=\s)</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>&quot;</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>&quot;|$</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.css</string>
+								</dict>
+							</dict>
 							<key>name</key>
-							<string>variable.parameter.url.css</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#string-single</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#string-double</string>
+							<string>string.quoted.double.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>begin</key>
+									<string>(?:\G|^)(?=(?:[^&quot;])+$)</string>
+									<key>end</key>
+									<string>$</string>
+									<key>name</key>
+									<string>invalid.illegal.unclosed.string.css</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#media-query-list</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>^\s*((@)font-face)\s*(?=\{)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.at-rule.font-face.css</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.keyword.css</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>name</key>
-			<string>meta.at-rule.font-face.css</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#rule-list</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>(?=^\s*@media\s*.*?\{)</string>
-			<key>end</key>
-			<string>\s*(\})</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.property-list.end.css</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
 					<key>begin</key>
-					<string>^\s*((@)media)(?=.*?\{)</string>
+					<string>(?i)((@)import)(?:\s+|$|(?=[&apos;&quot;]|/\*))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.control.at-rule.media.css</string>
+							<string>keyword.control.at-rule.import.css</string>
 						</dict>
 						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.keyword.css</string>
 						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>support.constant.media.css</string>
-						</dict>
 					</dict>
 					<key>end</key>
-					<string>\s*(?=\{)</string>
+					<string>;</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.terminator.rule.css</string>
+						</dict>
+					</dict>
 					<key>name</key>
-					<string>meta.at-rule.media.css</string>
+					<string>meta.at-rule.import.css</string>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>begin</key>
+							<string>\G\s*(?=/\*)</string>
+							<key>end</key>
+							<string>(?&lt;=\*/)\s*</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#string</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#url</string>
+						</dict>
 						<dict>
 							<key>include</key>
 							<string>#media-query-list</string>
@@ -211,66 +245,1408 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>\s*(\{)</string>
+					<string>(?i)((@)font-face)(?=\s*|{|/\*|$)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.property-list.begin.css</string>
+							<string>keyword.control.at-rule.font-face.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.keyword.css</string>
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?=\})</string>
+					<string>(?!\G)</string>
+					<key>name</key>
+					<string>meta.at-rule.font-face.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>include</key>
-							<string>$self</string>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#rule-list</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(@)page(?=[\s:{]|/\*|$)</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.at-rule.page.css</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.keyword.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\s*($|[:{;]))</string>
+					<key>name</key>
+					<string>meta.at-rule.page.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#rule-list</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@media(\s|\(|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)media</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.media.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*[{;])</string>
+							<key>name</key>
+							<string>meta.at-rule.media.header.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#media-query-list</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.media.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.media.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.media.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@counter-style([\s&apos;&quot;{;]|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)counter-style</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.counter-style.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*{)</string>
+							<key>name</key>
+							<string>meta.at-rule.counter-style.header.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>captures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>include</key>
+													<string>#escapes</string>
+												</dict>
+											</array>
+										</dict>
+									</dict>
+									<key>match</key>
+									<string>(?x)
+(?:[-a-zA-Z_]    | [^\x00-\x7F])     # First letter
+(?:[-a-zA-Z0-9_] | [^\x00-\x7F]      # Remainder of identifier
+  |\\(?:[0-9a-fA-F]{1,6}|.)
+)*</string>
+									<key>name</key>
+									<string>variable.parameter.style-name.css</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.property-list.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.property-list.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.counter-style.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#rule-list-innards</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@document([\s&apos;&quot;{;]|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)document</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.document.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*[{;])</string>
+							<key>name</key>
+							<string>meta.at-rule.document.header.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>begin</key>
+									<string>(?i)(?&lt;![\w-])(url-prefix|domain|regexp)(\()</string>
+									<key>beginCaptures</key>
+									<dict>
+										<key>1</key>
+										<dict>
+											<key>name</key>
+											<string>support.function.document-rule.css</string>
+										</dict>
+										<key>2</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.function.begin.bracket.round.css</string>
+										</dict>
+									</dict>
+									<key>end</key>
+									<string>\)</string>
+									<key>endCaptures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.function.end.bracket.round.css</string>
+										</dict>
+									</dict>
+									<key>name</key>
+									<string>meta.function.document-rule.css</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#string</string>
+										</dict>
+										<dict>
+											<key>include</key>
+											<string>#comment-block</string>
+										</dict>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+										<dict>
+											<key>match</key>
+											<string>[^&apos;&quot;)\s]+</string>
+											<key>name</key>
+											<string>variable.parameter.document-rule.css</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#url</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#commas</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.document.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.document.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.document.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@(?:-(?:webkit|moz|o|ms)-)?keyframes([\s&apos;&quot;{;]|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)(?:-(?:webkit|moz|o|ms)-)?keyframes</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.keyframes.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*{)</string>
+							<key>name</key>
+							<string>meta.at-rule.keyframes.header.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>captures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>include</key>
+													<string>#escapes</string>
+												</dict>
+											</array>
+										</dict>
+									</dict>
+									<key>match</key>
+									<string>(?x)
+(?:[-a-zA-Z_]    | [^\x00-\x7F])     # First letter
+(?:[-a-zA-Z0-9_] | [^\x00-\x7F]      # Remainder of identifier
+  |\\(?:[0-9a-fA-F]{1,6}|.)
+)*</string>
+									<key>name</key>
+									<string>variable.parameter.keyframe-list.css</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.keyframes.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.keyframes.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.keyframes.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>captures</key>
+									<dict>
+										<key>1</key>
+										<dict>
+											<key>name</key>
+											<string>entity.other.keyframe-offset.css</string>
+										</dict>
+										<key>2</key>
+										<dict>
+											<key>name</key>
+											<string>entity.other.keyframe-offset.percentage.css</string>
+										</dict>
+									</dict>
+									<key>match</key>
+									<string>(?xi)
+(?&lt;![\w-]) (from|to) (?![\w-])         # Keywords for 0% | 100%
+|
+([-+]?(?:\d+(?:\.\d+)?|\.\d+)%)     # Percentile value</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#rule-list</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@supports(\s|\(|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)|(?=;)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)supports</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.supports.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*[{;])</string>
+							<key>name</key>
+							<string>meta.at-rule.supports.header.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#feature-query-operators</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#feature-query</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#comment-block</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.supports.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.supports.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.supports.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((@)(-(ms|o)-)?viewport)(?=[\s&apos;&quot;{;]|/\*|$)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.at-rule.viewport.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.keyword.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\s*[@{;])</string>
+					<key>name</key>
+					<string>meta.at-rule.viewport.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((@)font-feature-values)(?=[\s&apos;&quot;{;]|/\*|$)\s*</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.at-rule.font-feature-values.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.keyword.css</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>variable.parameter.font-name.css</string>
+					<key>end</key>
+					<string>(?=\s*[@{;])</string>
+					<key>name</key>
+					<string>meta.at-rule.font-features.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#font-features</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((@)namespace)(?=[\s&apos;&quot;;]|/\*|$)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.at-rule.namespace.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.keyword.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>;|(?=[@{])</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.terminator.rule.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.at-rule.namespace.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#url</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#comment-block</string>
+										</dict>
+									</array>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>entity.name.function.namespace-prefix.css</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?xi)
+(?:\G|^|(?&lt;=\s))
+(?=
+  (?&lt;=\s|^)                             # Starts with whitespace
+  (?:[-a-zA-Z_]|[^\x00-\x7F])          # Then a valid identifier character
+  |
+  \s*                                   # Possible adjoining whitespace
+  /\*(?:[^*]|\*[^/])*\*/              # Injected comment
+)
+(.*?)                                    # Grouped to embed #comment-block
+(
+  (?:[-a-zA-Z_]    | [^\x00-\x7F])     # First letter
+  (?:[-a-zA-Z0-9_] | [^\x00-\x7F]      # Remainder of identifier
+    |\\(?:[0-9a-fA-F]{1,6}|.)
+  )*
+)</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#string</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@[\w-]+[^;]+;s*$)</string>
+					<key>end</key>
+					<string>(?&lt;=;)(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)[\w-]+</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>;</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.terminator.rule.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.header.css</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?=@[\w-]+(\s|\(|{|/\*|$))</string>
+					<key>end</key>
+					<string>(?&lt;=})(?!\G)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?i)\G(@)[\w-]+</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.at-rule.css</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.keyword.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=\s*[{;])</string>
+							<key>name</key>
+							<string>meta.at-rule.header.css</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>{</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.begin.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>}</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.end.bracket.curly.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>meta.at-rule.body.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 			</array>
 		</dict>
-		<dict>
-			<key>begin</key>
-			<string>(?=\{)</string>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#rule-list</string>
-				</dict>
-			</array>
-		</dict>
-	</array>
-	<key>repository</key>
-	<dict>
-		<key>color-values</key>
+		<key>color-keywords</key>
 		<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>comment</key>
-					<string>http://www.w3.org/TR/CSS21/syndata.html#value-def-color</string>
 					<key>match</key>
-					<string>\b(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow)\b</string>
+					<string>(?i)(?&lt;![\w-])(aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow)(?![\w-])</string>
 					<key>name</key>
 					<string>support.constant.color.w3c-standard-color-name.css</string>
 				</dict>
 				<dict>
-					<key>comment</key>
-					<string>These colours are mostly recognised but will not validate. ref: http://www.w3schools.com/css/css_colornames.asp</string>
 					<key>match</key>
-					<string>\b(aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|turquoise|violet|wheat|whitesmoke|yellowgreen)\b</string>
+					<string>(?xi) (?&lt;![\w-])
+(aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood
+|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan
+|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange
+|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise
+|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen
+|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki
+|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow
+|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray
+|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue
+|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise
+|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered
+|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum
+|powderblue|rebeccapurple|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell
+|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato
+|transparent|turquoise|violet|wheat|whitesmoke|yellowgreen)
+(?![\w-])</string>
 					<key>name</key>
-					<string>invalid.deprecated.color.w3c-non-standard-color-name.css</string>
+					<string>support.constant.color.w3c-extended-color-name.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i)(?&lt;![\w-])currentColor(?![\w-])</string>
+					<key>name</key>
+					<string>support.constant.color.current.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?xi) (?&lt;![\w-])
+(ActiveBorder|ActiveCaption|AppWorkspace|Background|ButtonFace|ButtonHighlight|ButtonShadow
+|ButtonText|CaptionText|GrayText|Highlight|HighlightText|InactiveBorder|InactiveCaption
+|InactiveCaptionText|InfoBackground|InfoText|Menu|MenuText|Scrollbar|ThreeDDarkShadow
+|ThreeDFace|ThreeDHighlight|ThreeDLightShadow|ThreeDShadow|Window|WindowFrame|WindowText)
+(?![\w-])</string>
+					<key>name</key>
+					<string>invalid.deprecated.color.system.css</string>
+				</dict>
+			</array>
+		</dict>
+		<key>combinators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>/deep/|&gt;&gt;&gt;</string>
+					<key>name</key>
+					<string>invalid.deprecated.combinator.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>&gt;&gt;|&gt;|\+|~</string>
+					<key>name</key>
+					<string>keyword.operator.combinator.css</string>
+				</dict>
+			</array>
+		</dict>
+		<key>commas</key>
+		<dict>
+			<key>match</key>
+			<string>,</string>
+			<key>name</key>
+			<string>punctuation.separator.list.comma.css</string>
+		</dict>
+		<key>comment-block</key>
+		<dict>
+			<key>begin</key>
+			<string>/\*</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.begin.css</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\*/</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.end.css</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>comment.block.css</string>
+		</dict>
+		<key>escapes</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\[0-9a-fA-F]{1,6}</string>
+					<key>name</key>
+					<string>constant.character.escape.codepoint.css</string>
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(hsla?|rgba?)\s*(\()</string>
+					<string>\\$\s*</string>
+					<key>end</key>
+					<string>^(?&lt;!\G)</string>
+					<key>name</key>
+					<string>constant.character.escape.newline.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>constant.character.escape.css</string>
+				</dict>
+			</array>
+		</dict>
+		<key>feature-query</key>
+		<dict>
+			<key>begin</key>
+			<string>\(</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.condition.begin.bracket.round.css</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.condition.end.bracket.round.css</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.feature-query.css</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#feature-query-operators</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#feature-query</string>
+				</dict>
+			</array>
+		</dict>
+		<key>feature-query-operators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?i)(?&lt;=[\s()]|^|\*/)(and|not|or)(?=[\s()]|/\*|$)</string>
+					<key>name</key>
+					<string>keyword.operator.logical.feature.$1.css</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#rule-list-innards</string>
+				</dict>
+			</array>
+		</dict>
+		<key>font-features</key>
+		<dict>
+			<key>begin</key>
+			<string>(?xi)
+((@)(annotation|character-variant|ornaments|styleset|stylistic|swash))
+(?=[\s@&apos;&quot;{;]|/\*|$)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.at-rule.${3:/downcase}.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.keyword.css</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=})</string>
+			<key>name</key>
+			<string>meta.at-rule.${3:/downcase}.css</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>{</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.property-list.begin.bracket.curly.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>}</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.property-list.end.bracket.curly.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.property-list.font-feature.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?x)
+(?: [-a-zA-Z_]    | [^\x00-\x7F] )   # First letter
+(?: [-a-zA-Z0-9_] | [^\x00-\x7F]     # Remainder of identifier
+  | \\(?:[0-9a-fA-F]{1,6}|.)
+)*</string>
+							<key>name</key>
+							<string>variable.font-feature.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#rule-list-innards</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>functional-pseudo-classes</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((:)dir)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.pseudo-class.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.entity.css</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>(?i)(?&lt;![\w-])(ltr|rtl)(?![\w-])</string>
+							<key>name</key>
+							<string>support.constant.text-direction.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((:)lang)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.pseudo-class.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.entity.css</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?&lt;=[(,\s])[a-zA-Z]+(-[a-zA-Z0-9]*|\\(?:[0-9a-fA-F]{1,6}|.))*(?=[),\s])</string>
+							<key>name</key>
+							<string>support.constant.language-range.css</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>&quot;</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>&quot;</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.double.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>(?&lt;=[&quot;\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*)*(?=[&quot;\s])</string>
+									<key>name</key>
+									<string>support.constant.language-range.css</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>&apos;</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.css</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>&apos;</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.css</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.single.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>(?&lt;=[&apos;\s])[a-zA-Z*]+(-[a-zA-Z0-9*]*)*(?=[&apos;\s])</string>
+									<key>name</key>
+									<string>support.constant.language-range.css</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#commas</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((:)(?:not|has|matches))(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.pseudo-class.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.entity.css</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#selector-innards</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)((:)nth-(?:last-)?(?:child|of-type))(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.pseudo-class.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.entity.css</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?i)[+-]?(\d+n?|n)(\s*[+-]\s*\d+)?</string>
+							<key>name</key>
+							<string>constant.numeric.css</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>(?i)even|odd</string>
+							<key>name</key>
+							<string>support.constant.parity.css</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>functions</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(calc)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.calc.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.calc.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>[*/]|(?&lt;=\s|^)[-+](?=\s|$)</string>
+							<key>name</key>
+							<string>keyword.operator.arithmetic.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(rgba?|hsla?)(\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -281,141 +1657,569 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.function.css</string>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))</string>
+					<string>\)</string>
 					<key>endCaptures</key>
 					<dict>
-						<key>1</key>
+						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.function.css</string>
+							<string>punctuation.section.function.end.bracket.round.css</string>
 						</dict>
 					</dict>
+					<key>name</key>
+					<string>meta.function.color.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>match</key>
-							<string>(?x)\b
-							    (0*((1?[0-9]{1,2})|(2([0-4][0-9]|5[0-5])))\s*,\s*){2}
-							    (0*((1?[0-9]{1,2})|(2([0-4][0-9]|5[0-5])))\b)
-							    (\s*,\s*((0?\.[0-9]+)|[0-1]))?
-							</string>
-							<key>name</key>
-							<string>constant.other.color.rgb-value.css</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>\b([0-9]{1,2}|100)\s*%,\s*([0-9]{1,2}|100)\s*%,\s*([0-9]{1,2}|100)\s*%</string>
-							<key>name</key>
-							<string>constant.other.color.rgb-percentage.css</string>
-						</dict>
-						<dict>
 							<key>include</key>
-							<string>#numeric-values</string>
+							<string>#property-values</string>
 						</dict>
 					</array>
 				</dict>
-			</array>
-		</dict>
-		<key>comment-block</key>
-		<dict>
-			<key>begin</key>
-			<string>/\*</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.comment.css</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\*/</string>
-			<key>name</key>
-			<string>comment.block.css</string>
-		</dict>
-		<key>media-query</key>
-		<dict>
-			<key>begin</key>
-			<string>(?i)\s*(only|not)?\s*(all|aural|braille|embossed|handheld|print|projection|screen|tty|tv)?</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.logic.media.css</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>support.constant.media.css</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>\s*(?:(,)|(?=[{;]))</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.arbitrary-repitition.css</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
 				<dict>
 					<key>begin</key>
-					<string>\s*(and)?\s*(\()\s*</string>
+					<string>(?xi) (?&lt;![\w-])
+(
+  (?:-webkit-|-moz-|-o-)?    # Accept prefixed/historical variants
+  (?:repeating-)?            # &quot;Repeating&quot;-type gradient
+  (?:linear|radial|conic)    # Shape
+  -gradient
+)
+(\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.operator.logic.media.css</string>
+							<string>support.function.gradient.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
 						</dict>
 					</dict>
 					<key>end</key>
 					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.gradient.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?i)(?&lt;![\w-])(from|to|at)(?![\w-])</string>
+							<key>name</key>
+							<string>keyword.operator.gradient.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(-webkit-gradient)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.deprecated.gradient.function.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.gradient.invalid.deprecated.gradient.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>(?x)
-	                            (
-	                                ((min|max)-)?
-	                                (
-	                                    ((device-)?(height|width|aspect-ratio))|
-	                                    (color(-index)?)|monochrome|resolution
-	                                )
-	                            )|grid|scan|orientation
-	                            \s*(?=[:)])</string>
+							<string>(?i)(?&lt;![\w-])(from|to|color-stop)(\()</string>
 							<key>beginCaptures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>support.type.property-name.media.css</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>(:)|(?=\))</string>
-							<key>endCaptures</key>
 							<dict>
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>punctuation.separator.key-value.css</string>
+									<string>invalid.deprecated.function.css</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.function.begin.bracket.round.css</string>
 								</dict>
 							</dict>
+							<key>end</key>
+							<string>\)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.section.function.end.bracket.round.css</string>
+								</dict>
+							</dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#property-values</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?xi) (?&lt;![\w-])
+(annotation|attr|blur|brightness|character-variant|contrast|counters?
+|cross-fade|drop-shadow|element|fit-content|format|grayscale|hue-rotate
+|image-set|invert|local|minmax|opacity|ornaments|repeat|saturate|sepia
+|styleset|stylistic|swash|symbols)
+(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.misc.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.misc.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?i)(?&lt;=[,\s&quot;]|\*/|^)\d+x(?=[\s,&quot;&apos;)]|/\*|$)</string>
+							<key>name</key>
+							<string>constant.numeric.other.density.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>\b(portrait|landscape|progressive|interlace)</string>
+							<string>[^&apos;&quot;),\s]+</string>
 							<key>name</key>
-							<string>support.constant.property-value.css</string>
+							<string>variable.parameter.misc.css</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(circle|ellipse|inset|polygon|rect)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.shape.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.shape.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?i)(?&lt;=\s|^|\*/)(at|round)(?=\s|/\*|$)</string>
+							<key>name</key>
+							<string>keyword.operator.shape.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(cubic-bezier|steps)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.timing-function.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.timing-function.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?i)(?&lt;![\w-])(start|end)(?=\s*\)|$)</string>
+							<key>name</key>
+							<string>support.constant.step-direction.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?xi) (?&lt;![\w-])
+( (?:translate|scale|rotate)(?:[XYZ]|3D)?
+| matrix(?:3D)?
+| skew[XY]?
+| perspective
+)
+(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.transform.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#url</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?i)(?&lt;![\w-])(var)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.function.misc.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.variable.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>match</key>
+							<string>(?x)
+--
+(?:[-a-zA-Z_]    | [^\x00-\x7F])     # First letter
+(?:[-a-zA-Z0-9_] | [^\x00-\x7F]      # Remainder of identifier
+  |\\(?:[0-9a-fA-F]{1,6}|.)
+)*</string>
+							<key>name</key>
+							<string>variable.argument.css</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#property-values</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>media-feature-keywords</key>
+		<dict>
+			<key>match</key>
+			<string>(?xi)
+(?&lt;=^|\s|:|\*/)
+(?: portrait                  # Orientation
+  | landscape
+  | progressive               # Scan types
+  | interlace
+  | fullscreen                # Display modes
+  | standalone
+  | minimal-ui
+  | browser
+  | hover
+)
+(?=\s|\)|$)</string>
+			<key>name</key>
+			<string>support.constant.property-value.css</string>
+		</dict>
+		<key>media-features</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.type.property-name.media.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>support.type.property-name.media.css</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>support.type.vendored.property-name.media.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?xi)
+(?&lt;=^|\s|\(|\*/)           # Preceded by whitespace, bracket or comment
+(?:
+  # Standardised features
+  (
+    (?:min-|max-)?            # Range features
+    (?: height
+      | width
+      | aspect-ratio
+      | color
+      | color-index
+      | monochrome
+      | resolution
+    )
+    | grid                    # Discrete features
+    | scan
+    | orientation
+    | display-mode
+    | hover
+  )
+  |
+  # Deprecated features
+  (
+    (?:min-|max-)?            # Deprecated in Media Queries 4
+    device-
+    (?: height
+      | width
+      | aspect-ratio
+    )
+  )
+  |
+  # Vendor extensions
+  (
+    (?:
+      # Spec-compliant syntax
+      [-_]
+      (?: webkit              # Webkit/Blink
+        | apple|khtml         # Webkit aliases
+        | epub                # ePub3
+        | moz                 # Gecko
+        | ms                  # Microsoft
+        | o                   # Presto (pre-Opera 15)
+        | xv|ah|rim|atsc|     # Less common vendors
+          hp|tc|wap|ro
+      )
+      |
+      # Non-standard prefixes
+      (?: mso                 # Microsoft Office
+        | prince              # YesLogic
+      )
+    )
+    -
+    [\w-]+                   # Feature name
+    (?=                       # Terminates correctly
+      \s*                    # Possible whitespace
+      (?:                     # Possible injected comment
+        /\*
+        (?:[^*]|\*[^/])*
+        \*/
+      )?
+      \s*
+      [:)]                    # Ends with a colon or closed bracket
+    )
+  )
+)
+(?=\s|$|[&gt;&lt;:=]|\)|/\*)     # Terminates cleanly</string>
+		</dict>
+		<key>media-query</key>
+		<dict>
+			<key>begin</key>
+			<string>\G</string>
+			<key>end</key>
+			<string>(?=\s*[{;])</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment-block</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#escapes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#media-types</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i)(?&lt;=\s|^|,|\*/)(only|not)(?=\s|{|/\*|$)</string>
+					<key>name</key>
+					<string>keyword.operator.logical.$1.media.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?i)(?&lt;=\s|^|\*/|\))and(?=\s|/\*|$)</string>
+					<key>name</key>
+					<string>keyword.operator.logical.and.media.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>,(?:(?:\s*,)+|(?=\s*[;){]))</string>
+					<key>name</key>
+					<string>invalid.illegal.comma.css</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#commas</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\(</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.begin.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.end.bracket.round.css</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#media-features</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#media-feature-keywords</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>:</string>
+							<key>name</key>
+							<string>punctuation.separator.key-value.css</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>&gt;=|&lt;=|=|&lt;|&gt;</string>
+							<key>name</key>
+							<string>keyword.operator.comparison.css</string>
 						</dict>
 						<dict>
 							<key>captures</key>
@@ -437,11 +2241,17 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>\s*(\d+)(/)(\d+)</string>
+							<string>(\d+)\s*(/)\s*(\d+)</string>
+							<key>name</key>
+							<string>meta.ratio.css</string>
 						</dict>
 						<dict>
 							<key>include</key>
 							<string>#numeric-values</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
 						</dict>
 					</array>
 				</dict>
@@ -450,9 +2260,9 @@
 		<key>media-query-list</key>
 		<dict>
 			<key>begin</key>
-			<string>\s*(?=[^{;])</string>
+			<string>(?=\s*[^{;])</string>
 			<key>end</key>
-			<string>\s*(?=[{;])</string>
+			<string>(?=\s*[{;])</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -460,6 +2270,33 @@
 					<string>#media-query</string>
 				</dict>
 			</array>
+		</dict>
+		<key>media-types</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.constant.media.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.deprecated.constant.media.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?xi)
+(?&lt;=^|\s|,|\*/)
+(?:
+  # Valid media types
+  (all|print|screen|speech)
+  |
+  # Deprecated in Media Queries 4: http://dev.w3.org/csswg/mediaqueries/#media-types
+  (aural|braille|embossed|handheld|projection|tty|tv)
+)
+(?=$|[{,\s;]|/\*)</string>
 		</dict>
 		<key>numeric-values</key>
 		<dict>
@@ -475,9 +2312,9 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b</string>
+					<string>(#)(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b</string>
 					<key>name</key>
-					<string>constant.other.color.rgb-value.css</string>
+					<string>constant.other.color.rgb-value.hex.css</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -485,16 +2322,219 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.unit.css</string>
+							<string>keyword.other.unit.percentage.css</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.unit.${2:/downcase}.css</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x)
-					    (?:-|\+)?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+))
-					    ((?:px|pt|ch|cm|mm|in|r?em|ex|pc|deg|g?rad|dpi|dpcm|s)\b|%)?
-					</string>
+					<string>(?xi) (?&lt;![\w-])
+[-+]?                               # Sign indicator
+
+(?:                                 # Numerals
+    [0-9]+ (?:\.[0-9]+)?           # Integer/float with leading digits
+  | \.[0-9]+                       # Float without leading digits
+)
+
+(?:                                 # Scientific notation
+  (?&lt;=[0-9])                        # Exponent must follow a digit
+  E                                 # Exponent indicator
+  [-+]?                             # Possible sign indicator
+  [0-9]+                            # Exponent value
+)?
+
+(?:                                 # Possible unit for data-type:
+  (%)                               # - Percentage
+  | ( deg|grad|rad|turn             # - Angle
+    | Hz|kHz                        # - Frequency
+    | ch|cm|em|ex|fr|in|mm|mozmm|   # - Length
+      pc|pt|px|q|rem|vh|vmax|vmin|
+      vw
+    | dpi|dpcm|dppx                 # - Resolution
+    | s|ms                          # - Time
+    )
+  \b                               # Boundary checking intentionally lax to
+)?                                  # facilitate embedding in CSS-like grammars</string>
 					<key>name</key>
 					<string>constant.numeric.css</string>
+				</dict>
+			</array>
+		</dict>
+		<key>property-keywords</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?xi) (?&lt;![\w-])
+(above|absolute|active|add|additive|after-edge|alias|all|all-petite-caps|all-scroll|all-small-caps|alpha|alphabetic|alternate|alternate-reverse
+|always|antialiased|auto|auto-pos|available|avoid|avoid-column|avoid-page|avoid-region|backwards|balance|baseline|before-edge|below|bevel
+|bidi-override|blink|block|block-axis|block-start|block-end|bold|bolder|border|border-box|both|bottom|bottom-outside|break-all|break-word|bullets
+|butt|capitalize|caption|cell|center|central|char|circle|clip|clone|close-quote|closest-corner|closest-side|col-resize|collapse|color|color-burn
+|color-dodge|column|column-reverse|common-ligatures|compact|condensed|contain|content|content-box|contents|context-menu|contextual|copy|cover
+|crisp-edges|crispEdges|crosshair|cyclic|darken|dashed|decimal|default|dense|diagonal-fractions|difference|digits|disabled|disc|discretionary-ligatures
+|distribute|distribute-all-lines|distribute-letter|distribute-space|dot|dotted|double|double-circle|downleft|downright|e-resize|each-line|ease|ease-in
+|ease-in-out|ease-out|economy|ellipse|ellipsis|embed|end|evenodd|ew-resize|exact|exclude|exclusion|expanded|extends|extra-condensed|extra-expanded
+|fallback|farthest-corner|farthest-side|fill|fill-available|fill-box|filled|fit-content|fixed|flat|flex|flex-end|flex-start|flip|flow-root|forwards|freeze
+|from-image|full-width|geometricPrecision|georgian|grab|grabbing|grayscale|grid|groove|hand|hanging|hard-light|help|hidden|hide
+|historical-forms|historical-ligatures|horizontal|horizontal-tb|hue|icon|ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space
+|ideographic|inactive|infinite|inherit|initial|inline|inline-axis|inline-block|inline-end|inline-flex|inline-grid|inline-list-item|inline-start
+|inline-table|inset|inside|inter-character|inter-ideograph|inter-word|intersect|invert|isolate|isolate-override|italic|jis04|jis78|jis83
+|jis90|justify|justify-all|kannada|keep-all|landscape|large|larger|left|lighten|lighter|line|line-edge|line-through|linear|linearRGB
+|lining-nums|list-item|local|loose|lowercase|lr|lr-tb|ltr|luminance|luminosity|main-size|mandatory|manipulation|manual|margin-box|match-parent
+|match-source|mathematical|max-content|medium|menu|message-box|middle|min-content|miter|mixed|move|multiply|n-resize|narrower|ne-resize
+|nearest-neighbor|nesw-resize|newspaper|no-change|no-clip|no-close-quote|no-common-ligatures|no-contextual|no-discretionary-ligatures
+|no-drop|no-historical-ligatures|no-open-quote|no-repeat|none|nonzero|normal|not-allowed|nowrap|ns-resize|numbers|numeric|nw-resize|nwse-resize
+|oblique|oldstyle-nums|open|open-quote|optimizeLegibility|optimizeQuality|optimizeSpeed|optional|ordinal|outset|outside|over|overlay|overline|padding
+|padding-box|page|painted|pan-down|pan-left|pan-right|pan-up|pan-x|pan-y|paused|petite-caps|pixelated|plaintext|pointer|portrait|pre|pre-line
+|pre-wrap|preserve-3d|progress|progressive|proportional-nums|proportional-width|proximity|radial|recto|region|relative|remove|repeat|repeat-[xy]
+|reset-size|reverse|revert|ridge|right|rl|rl-tb|round|row|row-resize|row-reverse|row-severse|rtl|ruby|ruby-base|ruby-base-container|ruby-text
+|ruby-text-container|run-in|running|s-resize|saturation|scale-down|screen|scroll|scroll-position|se-resize|semi-condensed|semi-expanded|separate
+|sesame|show|sideways|sideways-left|sideways-lr|sideways-right|sideways-rl|simplified|slashed-zero|slice|small|small-caps|small-caption|smaller
+|smooth|soft-light|solid|space|space-around|space-between|space-evenly|spell-out|square|sRGB|stacked-fractions|start|static|status-bar|swap
+|step-end|step-start|sticky|stretch|strict|stroke|stroke-box|style|sub|subgrid|subpixel-antialiased|subtract|super|sw-resize|symbolic|table
+|table-caption|table-cell|table-column|table-column-group|table-footer-group|table-header-group|table-row|table-row-group|tabular-nums|tb|tb-rl
+|text|text-after-edge|text-before-edge|text-bottom|text-top|thick|thin|titling-caps|top|top-outside|touch|traditional|transparent|triangle
+|ultra-condensed|ultra-expanded|under|underline|unicase|unset|upleft|uppercase|upright|use-glyph-orientation|use-script|verso|vertical
+|vertical-ideographic|vertical-lr|vertical-rl|vertical-text|view-box|visible|visibleFill|visiblePainted|visibleStroke|w-resize|wait|wavy
+|weight|whitespace|wider|words|wrap|wrap-reverse|x|x-large|x-small|xx-large|xx-small|y|zero|zoom-in|zoom-out)
+(?![\w-])</string>
+					<key>name</key>
+					<string>support.constant.property-value.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?xi) (?&lt;![\w-])
+(arabic-indic|armenian|bengali|cambodian|circle|cjk-decimal|cjk-earthly-branch|cjk-heavenly-stem|cjk-ideographic
+|decimal|decimal-leading-zero|devanagari|disc|disclosure-closed|disclosure-open|ethiopic-halehame-am
+|ethiopic-halehame-ti-e[rt]|ethiopic-numeric|georgian|gujarati|gurmukhi|hangul|hangul-consonant|hebrew
+|hiragana|hiragana-iroha|japanese-formal|japanese-informal|kannada|katakana|katakana-iroha|khmer
+|korean-hangul-formal|korean-hanja-formal|korean-hanja-informal|lao|lower-alpha|lower-armenian|lower-greek
+|lower-latin|lower-roman|malayalam|mongolian|myanmar|oriya|persian|simp-chinese-formal|simp-chinese-informal
+|square|tamil|telugu|thai|tibetan|trad-chinese-formal|trad-chinese-informal|upper-alpha|upper-armenian
+|upper-latin|upper-roman|urdu)
+(?![\w-])</string>
+					<key>name</key>
+					<string>support.constant.property-value.list-style-type.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;![\w-])(?i:-(?:ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)|(?:mso|prince))-[a-zA-Z-]+</string>
+					<key>name</key>
+					<string>support.constant.vendored.property-value.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;![\w-])(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system-ui|system|tahoma|times|trebuchet|ui-monospace|ui-rounded|ui-sans-serif|ui-serif|utopia|verdana|webdings|sans-serif|serif|monospace)(?![\w-])</string>
+					<key>name</key>
+					<string>support.constant.font-name.css</string>
+				</dict>
+			</array>
+		</dict>
+		<key>property-names</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?xi) (?&lt;![\w-])
+(?:
+  # Standard CSS
+  additive-symbols|align-content|align-items|align-self|all|animation|animation-delay|animation-direction|animation-duration
+  | animation-fill-mode|animation-iteration-count|animation-name|animation-play-state|animation-timing-function|backdrop-filter
+  | backface-visibility|background|background-attachment|background-blend-mode|background-clip|background-color|background-image
+  | background-origin|background-position|background-position-[xy]|background-repeat|background-size|bleed|block-size|border
+  | border-block-end|border-block-end-color|border-block-end-style|border-block-end-width|border-block-start|border-block-start-color
+  | border-block-start-style|border-block-start-width|border-bottom|border-bottom-color|border-bottom-left-radius|border-bottom-right-radius
+  | border-bottom-style|border-bottom-width|border-collapse|border-color|border-end-end-radius|border-end-start-radius|border-image
+  | border-image-outset|border-image-repeat|border-image-slice|border-image-source|border-image-width|border-inline-end
+  | border-inline-end-color|border-inline-end-style|border-inline-end-width|border-inline-start|border-inline-start-color
+  | border-inline-start-style|border-inline-start-width|border-left|border-left-color|border-left-style|border-left-width
+  | border-radius|border-right|border-right-color|border-right-style|border-right-width|border-spacing|border-start-end-radius
+  | border-start-start-radius|border-style|border-top|border-top-color|border-top-left-radius|border-top-right-radius|border-top-style
+  | border-top-width|border-width|bottom|box-decoration-break|box-shadow|box-sizing|break-after|break-before|break-inside|caption-side
+  | caret-color|clear|clip|clip-path|clip-rule|color|color-adjust|color-interpolation-filters|column-count|column-fill|column-gap
+  | column-rule|column-rule-color|column-rule-style|column-rule-width|column-span|column-width|columns|contain|content|counter-increment
+  | counter-reset|cursor|direction|display|empty-cells|enable-background|fallback|fill|fill-opacity|fill-rule|filter|flex|flex-basis
+  | flex-direction|flex-flow|flex-grow|flex-shrink|flex-wrap|float|flood-color|flood-opacity|font|font-display|font-family
+  | font-feature-settings|font-kerning|font-language-override|font-optical-sizing|font-size|font-size-adjust|font-stretch
+  | font-style|font-synthesis|font-variant|font-variant-alternates|font-variant-caps|font-variant-east-asian|font-variant-ligatures
+  | font-variant-numeric|font-variant-position|font-variation-settings|font-weight|gap|glyph-orientation-horizontal|glyph-orientation-vertical
+  | grid|grid-area|grid-auto-columns|grid-auto-flow|grid-auto-rows|grid-column|grid-column-end|grid-column-gap|grid-column-start
+  | grid-gap|grid-row|grid-row-end|grid-row-gap|grid-row-start|grid-template|grid-template-areas|grid-template-columns|grid-template-rows
+  | hanging-punctuation|height|hyphens|image-orientation|image-rendering|image-resolution|ime-mode|initial-letter|initial-letter-align
+  | inline-size|inset|inset-block|inset-block-end|inset-block-start|inset-inline|inset-inline-end|inset-inline-start|isolation
+  | justify-content|justify-items|justify-self|kerning|left|letter-spacing|lighting-color|line-break|line-clamp|line-height|list-style
+  | list-style-image|list-style-position|list-style-type|margin|margin-block-end|margin-block-start|margin-bottom|margin-inline-end|margin-inline-start
+  | margin-left|margin-right|margin-top|marker-end|marker-mid|marker-start|marks|mask|mask-border|mask-border-mode|mask-border-outset
+  | mask-border-repeat|mask-border-slice|mask-border-source|mask-border-width|mask-clip|mask-composite|mask-image|mask-mode
+  | mask-origin|mask-position|mask-repeat|mask-size|mask-type|max-block-size|max-height|max-inline-size|max-lines|max-width
+  | max-zoom|min-block-size|min-height|min-inline-size|min-width|min-zoom|mix-blend-mode|negative|object-fit|object-position
+  | offset|offset-anchor|offset-distance|offset-path|offset-position|offset-rotation|opacity|order|orientation|orphans
+  | outline|outline-color|outline-offset|outline-style|outline-width|overflow|overflow-anchor|overflow-block|overflow-inline
+  | overflow-wrap|overflow-[xy]|overscroll-behavior|overscroll-behavior-block|overscroll-behavior-inline|overscroll-behavior-[xy]
+  | pad|padding|padding-block-end|padding-block-start|padding-bottom|padding-inline-end|padding-inline-start|padding-left
+  | padding-right|padding-top|page-break-after|page-break-before|page-break-inside|paint-order|perspective|perspective-origin
+  | place-content|place-items|place-self|pointer-events|position|prefix|quotes|range|resize|right|rotate|row-gap|ruby-align
+  | ruby-merge|ruby-position|scale|scroll-behavior|scroll-margin|scroll-margin-block|scroll-margin-block-end|scroll-margin-block-start
+  | scroll-margin-bottom|scroll-margin-inline|scroll-margin-inline-end|scroll-margin-inline-start|scroll-margin-left|scroll-margin-right
+  | scroll-margin-top|scroll-padding|scroll-padding-block|scroll-padding-block-end|scroll-padding-block-start|scroll-padding-bottom
+  | scroll-padding-inline|scroll-padding-inline-end|scroll-padding-inline-start|scroll-padding-left|scroll-padding-right
+  | scroll-padding-top|scroll-snap-align|scroll-snap-coordinate|scroll-snap-destination|scroll-snap-stop|scroll-snap-type
+  | scrollbar-color|scrollbar-gutter|scrollbar-width|shape-image-threshold|shape-margin|shape-outside|shape-rendering|size
+  | speak-as|src|stop-color|stop-opacity|stroke|stroke-dasharray|stroke-dashoffset|stroke-linecap|stroke-linejoin|stroke-miterlimit
+  | stroke-opacity|stroke-width|suffix|symbols|system|tab-size|table-layout|text-align|text-align-last|text-anchor|text-combine-upright
+  | text-decoration|text-decoration-color|text-decoration-line|text-decoration-skip|text-decoration-skip-ink|text-decoration-style
+  | text-emphasis|text-emphasis-color|text-emphasis-position|text-emphasis-style|text-indent|text-justify|text-orientation
+  | text-overflow|text-rendering|text-shadow|text-size-adjust|text-transform|text-underline-position|top|touch-action|transform
+  | transform-box|transform-origin|transform-style|transition|transition-delay|transition-duration|transition-property|transition-timing-function
+  | translate|unicode-bidi|unicode-range|user-select|user-zoom|vertical-align|visibility|white-space|widows|width|will-change
+  | word-break|word-spacing|word-wrap|writing-mode|z-index|zoom
+
+  # SVG attributes
+  | alignment-baseline|baseline-shift|clip-rule|color-interpolation|color-interpolation-filters|color-profile
+  | color-rendering|cx|cy|dominant-baseline|enable-background|fill|fill-opacity|fill-rule|flood-color|flood-opacity
+  | glyph-orientation-horizontal|glyph-orientation-vertical|height|kerning|lighting-color|marker-end|marker-mid
+  | marker-start|r|rx|ry|shape-rendering|stop-color|stop-opacity|stroke|stroke-dasharray|stroke-dashoffset|stroke-linecap
+  | stroke-linejoin|stroke-miterlimit|stroke-opacity|stroke-width|text-anchor|width|x|y
+
+  # Not listed on MDN; presumably deprecated
+  | adjust|after|align|align-last|alignment|alignment-adjust|appearance|attachment|azimuth|background-break
+  | balance|baseline|before|bidi|binding|bookmark|bookmark-label|bookmark-level|bookmark-target|border-length
+  | bottom-color|bottom-left-radius|bottom-right-radius|bottom-style|bottom-width|box|box-align|box-direction
+  | box-flex|box-flex-group|box-lines|box-ordinal-group|box-orient|box-pack|break|character|collapse|column
+  | column-break-after|column-break-before|count|counter|crop|cue|cue-after|cue-before|decoration|decoration-break
+  | delay|display-model|display-role|down|drop|drop-initial-after-adjust|drop-initial-after-align|drop-initial-before-adjust
+  | drop-initial-before-align|drop-initial-size|drop-initial-value|duration|elevation|emphasis|family|fit|fit-position
+  | flex-group|float-offset|gap|grid-columns|grid-rows|hanging-punctuation|header|hyphenate|hyphenate-after|hyphenate-before
+  | hyphenate-character|hyphenate-lines|hyphenate-resource|icon|image|increment|indent|index|initial-after-adjust
+  | initial-after-align|initial-before-adjust|initial-before-align|initial-size|initial-value|inline-box-align|iteration-count
+  | justify|label|left-color|left-style|left-width|length|level|line|line-stacking|line-stacking-ruby|line-stacking-shift
+  | line-stacking-strategy|lines|list|mark|mark-after|mark-before|marks|marquee|marquee-direction|marquee-play-count|marquee-speed
+  | marquee-style|max|min|model|move-to|name|nav|nav-down|nav-index|nav-left|nav-right|nav-up|new|numeral|offset|ordinal-group
+  | orient|origin|overflow-style|overhang|pack|page|page-policy|pause|pause-after|pause-before|phonemes|pitch|pitch-range
+  | play-count|play-during|play-state|point|presentation|presentation-level|profile|property|punctuation|punctuation-trim
+  | radius|rate|rendering-intent|repeat|replace|reset|resolution|resource|respond-to|rest|rest-after|rest-before|richness
+  | right-color|right-style|right-width|role|rotation|rotation-point|rows|ruby|ruby-overhang|ruby-span|rule|rule-color
+  | rule-style|rule-width|shadow|size|size-adjust|sizing|space|space-collapse|spacing|span|speak|speak-header|speak-numeral
+  | speak-punctuation|speech|speech-rate|speed|stacking|stacking-ruby|stacking-shift|stacking-strategy|stress|stretch
+  | string-set|style|style-image|style-position|style-type|target|target-name|target-new|target-position|text|text-height
+  | text-justify|text-outline|text-replace|text-wrap|timing-function|top-color|top-left-radius|top-right-radius|top-style
+  | top-width|trim|unicode|up|user-select|variant|voice|voice-balance|voice-duration|voice-family|voice-pitch|voice-pitch-range
+  | voice-rate|voice-stress|voice-volume|volume|weight|white|white-space-collapse|word|wrap
+)
+(?![\w-])</string>
+					<key>name</key>
+					<string>support.type.property-name.css</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;![\w-])(?i:-(?:ah|apple|atsc|epub|hp|khtml|moz|ms|o|rim|ro|tc|wap|webkit|xv)|(?:mso|prince))-[a-zA-Z-]+</string>
+					<key>name</key>
+					<string>support.type.vendored.property-name.css</string>
 				</dict>
 			</array>
 		</dict>
@@ -503,16 +2543,28 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>\b(absolute|all(-scroll)?|always|armenian|auto|avoid|baseline|below|bidi-override|block|bold|bolder|both|bottom|break-all|break-word|capitalize|center|char|circle|cjk-ideographic|col-resize|collapse|crosshair|dashed|decimal-leading-zero|decimal|default|disabled|disc|distribute-all-lines|distribute-letter|distribute-space|distribute|dotted|double|e-resize|ellipsis|fixed|flat|geometricPrecision|georgian|groove|hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|inherit|initial|inline-block|inline|inset|inside|inter-ideograph|inter-word|italic|justify|katakana-iroha|katakana|keep-all|left|lighter|line-edge|line-through|line|list-item|loose|lower-alpha|lower-greek|lower-latin|lower-roman|lowercase|lr-tb|ltr|medium|middle|move|n-resize|ne-resize|newspaper|no-drop|no-repeat|nw-resize|none|normal|not-allowed|nowrap|oblique|optimize(Legibility|Quality|Speed)|outset|outside|overline|pointer|pre(-(wrap|line))?|preserve-3d|progress|relative|repeat-x|repeat-y|repeat|right|ridge|row-resize|rtl|s-resize|scroll|se-resize|separate|small-caps|solid|square|static|strict|sub|super|sw-resize|table-footer-group|table-header-group|tb-rl|text-bottom|text-top|text|thick|thin|top|transparent|underline|upper-alpha|upper-latin|upper-roman|uppercase|vertical(-(ideographic|text))|visible(Painted|Fill|Stroke)?|w-resize|wait|whitespace|zero|smaller|larger|((xx?-)?(small|large))|painted|fill|stroke|column|column-reverse|contain|cover|fill|flex-end|flex-start|row|row-reverse|scale-down|space-around|space-between|stretch|wrap|wrap-reverse|reverse|alternate-reverse|alternate|forwards|backwards|infinite|ease|ease-in|ease-out|ease-in-out|linear|step-start|step-end|steps|cubic-bezier|running|paused|sticky|page|soft-light|screen|saturation|overlay|multiply|luminosity|lighten|hue|hard-light|exclusion|difference|darken|color-dodge|color-burn|color|view-box|stroke-box|fill-box|border-box|padding-box|content-box|round|space|currentColor|subgrid|auto-fill|min-content|max-content|row|column|dense|minmax|calc|translate|translateX|translateY|translateZ|scale|scaleX|scaleY|scaleZ|rotate|rotateX|rotateY|rotateZ|skew|skewX|skewY|skewZ|linear-gradient|repeating-linear-gradient|radial-gradient|repeating-radial-gradient|farthest-side|closest-side|farthest-corner|closest-corner|ellipse|circle)\b</string>
-					<key>name</key>
-					<string>support.constant.property-value.css</string>
+					<key>include</key>
+					<string>#commas</string>
 				</dict>
 				<dict>
-					<key>match</key>
-					<string>(\b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace)\b)</string>
-					<key>name</key>
-					<string>support.constant.font-name.css</string>
+					<key>include</key>
+					<string>#comment-block</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#escapes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#functions</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#property-keywords</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#unicode-range</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -520,156 +2572,111 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#color-values</string>
+					<string>#color-keywords</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#string-double</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(rect)\s*(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.misc.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(\))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#numeric-values</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(format|local|url|attr|counter|counters)\s*(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.misc.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(\))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#string-single</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#string-double</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>[^'") \t]+</string>
-							<key>name</key>
-							<string>variable.parameter.misc.css</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(matrix(3d)?|perspective|(rotate|scale|translate)([XYZ]|3d)?|skew[XY]?)\s*(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.transform.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(\))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#numeric-values</string>
-						</dict>
-					</array>
+					<string>#string</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\!\s*important</string>
+					<string>!\s*important(?![\w-])</string>
 					<key>name</key>
 					<string>keyword.other.important.css</string>
 				</dict>
 			</array>
 		</dict>
+		<key>pseudo-classes</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.entity.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.colon.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?xi)
+(:)(:*)
+(?: active|any-link|checked|default|disabled|empty|enabled|first
+  | (?:first|last|only)-(?:child|of-type)|focus|focus-visible|focus-within|fullscreen|host|hover
+  | in-range|indeterminate|invalid|left|link|optional|out-of-range
+  | read-only|read-write|required|right|root|scope|target|unresolved
+  | valid|visited
+)(?![\w-]|\s*[;}])</string>
+			<key>name</key>
+			<string>entity.other.attribute-name.pseudo-class.css</string>
+		</dict>
+		<key>pseudo-elements</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.entity.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.entity.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?xi)
+(?:
+  (::?)                       # Elements using both : and :: notation
+  (?: after
+    | before
+    | first-letter
+    | first-line
+    | (?:-(?:ah|apple|atsc|epub|hp|khtml|moz
+            |ms|o|rim|ro|tc|wap|webkit|xv)
+        | (?:mso|prince))
+      -[a-z-]+
+  )
+  |
+  (::)                        # Double-colon only
+  (?: backdrop
+    | content
+    | grammar-error
+    | marker
+    | placeholder
+    | selection
+    | shadow
+    | spelling-error
+  )
+)
+(?![\w-]|\s*[;}])</string>
+			<key>name</key>
+			<string>entity.other.attribute-name.pseudo-element.css</string>
+		</dict>
 		<key>rule-list</key>
 		<dict>
 			<key>begin</key>
-			<string>\{</string>
+			<string>{</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.section.property-list.begin.css</string>
+					<string>punctuation.section.property-list.begin.bracket.curly.css</string>
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\}</string>
+			<string>}</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.section.property-list.end.css</string>
+					<string>punctuation.section.property-list.end.bracket.curly.css</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -678,28 +2685,49 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#rule-list-innards</string>
+				</dict>
+			</array>
+		</dict>
+		<key>rule-list-innards</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
 					<string>#comment-block</string>
 				</dict>
 				<dict>
+					<key>include</key>
+					<string>#escapes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#font-features</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?x) (?&lt;![\w-])
+--
+(?:[-a-zA-Z_]    | [^\x00-\x7F])     # First letter
+(?:[-a-zA-Z0-9_] | [^\x00-\x7F]      # Remainder of identifier
+  |\\(?:[0-9a-fA-F]{1,6}|.)
+)*</string>
+					<key>name</key>
+					<string>variable.css</string>
+				</dict>
+				<dict>
 					<key>begin</key>
-					<string>(?&lt;![-a-z])(?=[-a-z])</string>
+					<string>(?&lt;![-a-zA-Z])(?=[-a-zA-Z])</string>
 					<key>end</key>
-					<string>$|(?![-a-z])</string>
+					<string>$|(?![-a-zA-Z])</string>
 					<key>name</key>
 					<string>meta.property-name.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>match</key>
-							<string>-(webkit|moz|o|ms|khtml)(-[A-Za-z]+)+\b</string>
-							<key>name</key>
-							<string>support.type.property-name.css</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>\b(zoom|z-index|y|x|writing-mode|wrap-through|wrap-flow|wrap|word-wrap|word-spacing|word-break|word|will-change|width|widows|white-space-collapse|white-space|white|weight|volume|voice-volume|voice-stress|voice-rate|voice-range|voice-pitch-range|voice-pitch|voice-family|voice-duration|voice-balance|voice|visibility|vertical-align|variant|user-select|up|unicode-bidi|unicode|trim|transition-timing-function|transition-duration|transition-delay|transition|transform-style|transform-origin|transform|top|timing-function|text-wrap|text-underline-position|text-transform|text-space-collapse|text-shadow|text-replace|text-overflow|text-outline|text-orientation|text-justify|text-indent|text-height|text-emphasis-style|text-emphasis-position|text-emphasis-color|text-emphasis|text-decoration-style|text-decoration-skip|text-decoration-line|text-decoration-color|text-decoration|text-combine-upright|text-align-last|text-align|text|target-position|target-new|target-name|target|table-layout|tab-size|style-type|style-position|style-image|style|stroke|string-set|stretch|stress|stacking-strategy|stacking-shift|stacking-ruby|stacking|src|speed|speech-rate|speech|speak-punctuation|speak-numeral|speak-header|speak-as|speak|span|spacing|space-collapse|space|sizing|size-adjust|size|shape-outside|shape-margin|shape-inside|shape-image-threshold|shadow|setting-named-strings-string-set-pro|scroll-snap-type|scroll-snap-stop|scroll-snap-margin-top|scroll-snap-margin-right|scroll-snap-margin-left|scroll-snap-margin-inline-start|scroll-snap-margin-inline-end|scroll-snap-margin-inline|scroll-snap-margin-bottom|scroll-snap-margin-block-start|scroll-snap-margin-block-end|scroll-snap-margin-block|scroll-snap-margin|scroll-snap-align|scroll-padding-top|scroll-padding-right|scroll-padding-left|scroll-padding-inline-start|scroll-padding-inline-end|scroll-padding-inline|scroll-padding-bottom|scroll-padding-block-start|scroll-padding-block-end|scroll-padding-block|scroll-padding|rule-width|rule-style|rule-color|rule|ruby-span|ruby-position|ruby-overhang|ruby-merge|ruby-align|ruby|rows|row-gap|rotation-point|rotation|rotating|role|right|richness|rest-before|rest-after|rest|respond-to|resource|resolution|resize|reset|replace|repeat|rendering-intent|region-fragment|rate|radius|quotes|punctuation-trim|punctuation|property|profile|presentation-level|presentation|position|polar-origin|polar-distance|polar-angle|polar-anchor|pointer-events|point|play-state|play-during|play-count|pitch-range|pitch|phonemes|perspective-origin|perspective|pause-before|pause-after|pause|page-policy|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|pack|overhang|overflow-y|overflow-x|overflow-wrap|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|origin|orientation|orient|ordinal-group|order|opacity|offset|object-position|object-fit|numeral|new|nav-up|nav-right|nav-left|nav-index|nav-down|nav-dir|nav|name|moving|move-to|model|min-width|min-height|min|max-width|max-lines|max-height|max|mask-type|mask-source-type|mask-size|mask-repeat|mask-position|mask-origin|mask-image|mask-clip|mask-box-width|mask-box-source|mask-box-slice|mask-box-repeat|mask-box-outset|mask-box|mask|marquee-style|marquee-speed|marquee-play-count|marquee-direction|marquee|marks|marker-side|mark-before|mark-after|mark|margin-top|margin-right|margin-left|margin-bottom|margin|list-style-type|list-style-position|list-style-image|list-style|list|lines|line-stacking-strategy|line-stacking-shift|line-stacking-ruby|line-stacking|line-snap|line-height|line-grid|line-break|line|lighting-color|level|letter-spacing|length|left|label|justify-self|justify-items|justify-content|justify|iteration-count|input-method-editor|inline-box-align|initial-value|initial-size|initial-letter|initial-before-align|initial-before-adjust|initial-after-align|initial-after-adjust|index|indent|increment|image-resolution|image-rendering|image-orientation|image|icon|hyphens|hyphenate-resource|hyphenate-lines|hyphenate-character|hyphenate-before|hyphenate-after|hyphenate|height|header|hanging-punctuation|grid-template-rows|grid-template-columns|grid-template-areas|grid-template|grid-rows|grid-row-start|grid-row-end|grid-row|grid-columns|grid-column-start|grid-column-end|grid-column|grid-auto-rows|grid-auto-flow|grid-auto-columns|grid-area|grid|gap|font-weight|font-variant-position|font-variant-numeric|font-variant-ligatures|font-variant-east-asian|font-variant-caps|font-variant-alternates|font-variant|font-synthesis|font-style|font-stretch|font-size-adjust|font-size|font-language-override|font-kerning|font-feature-settings|font-family|font|flow-into|flow-from|flood-opacity|flood-color|float-offset|float|flex-wrap|flex-shrink|flex-grow|flex-group|flex-flow|flex-direction|flex-basis|flex|fit-position|fit|filter|fill|family|empty-cells|emphasis|elevation|duration|drop-initial-value|drop-initial-size|drop-initial-before-align|drop-initial-before-adjust|drop-initial-after-align|drop-initial-after-adjust|drop|down|dominant-baseline|display-role|display-outside|display-model|display-list|display-inside|display|direction|delay|decoration-break|decoration|cursor|cue-before|cue-after|cue|crop|counter-set|counter-reset|counter-increment|counter|count|content|contain|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|column-break-before|column-break-after|column|color-profile|color-interpolation-filters|color|collapse|clip-rule|clip-path|clip|clear|character|chains|caption-side|break-inside|break-before|break-after|break|box-suppress|box-snap|box-sizing|box-shadow|box-pack|box-orient|box-ordinal-group|box-lines|box-flex-group|box-flex|box-direction|box-decoration-break|box-align|box|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-length|border-left-width|border-left-style|border-left-color|border-left|border-image-width|border-image-source|border-image-slice|border-image-repeat|border-image-outset|border-image|border-color|border-collapse|border-boundary|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-target|bookmark-state|bookmark-level|bookmark-label|bookmark|bleed|binding|bidi|before|baseline-shift|baseline|balance|background-size|background-repeat|background-position|background-origin|background-image|background-color|background-clip|background-break|background-attachment|background|backface-visibility|azimuth|attachment|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-fill-mode|animation-duration|animation-direction|animation-delay|animation|all|alignment-baseline|alignment-adjust|alignment|align-self|align-last|align-items|align-content|align|after|adjust)\b</string>
-							<key>name</key>
-							<string>support.type.property-name.css</string>
+							<key>include</key>
+							<string>#property-names</string>
 						</dict>
 					</array>
 				</dict>
@@ -714,8 +2742,10 @@
 							<string>punctuation.separator.key-value.css</string>
 						</dict>
 					</dict>
+					<key>contentName</key>
+					<string>meta.property-value.css</string>
 					<key>end</key>
-					<string>\s*(;|(?=\}))</string>
+					<string>\s*(;)|\s*(?=}|\))</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -724,33 +2754,72 @@
 							<string>punctuation.terminator.rule.css</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>meta.property-value.css</string>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>include</key>
+							<string>#comment-block</string>
+						</dict>
 						<dict>
 							<key>include</key>
 							<string>#property-values</string>
 						</dict>
 					</array>
 				</dict>
+				<dict>
+					<key>match</key>
+					<string>;</string>
+					<key>name</key>
+					<string>punctuation.terminator.rule.css</string>
+				</dict>
 			</array>
 		</dict>
 		<key>selector</key>
 		<dict>
 			<key>begin</key>
-			<string>\s*(?=[:.*#a-zA-Z])</string>
+			<string>(?x)
+(?=
+  (?:\|)?                    # Possible anonymous namespace prefix
+  (?:
+    [-\[:.*\#a-zA-Z_]       # Valid selector character
+    |
+    [^\x00-\x7F]            # Which can include non-ASCII symbols
+    |
+    \\                      # Or an escape sequence
+    (?:[0-9a-fA-F]{1,6}|.)
+  )
+)</string>
 			<key>end</key>
-			<string>(?=[/@{)])</string>
+			<string>(?=\s*[/@{)])</string>
 			<key>name</key>
 			<string>meta.selector.css</string>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>\b(a|abbr|acronym|address|area|article|aside|audio|b|base|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|menu|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|pre|progress|q|samp|script|section|select|small|span|strike|strong|style|sub|summary|sup|table|tbody|td|textarea|tfoot|th|thead|time|title|tr|tt|ul|var|video)\b</string>
-					<key>name</key>
-					<string>entity.name.tag.css</string>
+					<key>include</key>
+					<string>#selector-innards</string>
+				</dict>
+			</array>
+		</dict>
+		<key>selector-innards</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment-block</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#commas</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#escapes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#combinators</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -758,27 +2827,38 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
+							<string>entity.other.namespace-prefix.css</string>
 						</dict>
-					</dict>
-					<key>match</key>
-					<string>(\.)[a-zA-Z0-9_-]+</string>
-					<key>name</key>
-					<string>entity.other.attribute-name.class.css</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
+						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
+							<string>punctuation.separator.css</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(#)[a-zA-Z][a-zA-Z0-9_-]*</string>
-					<key>name</key>
-					<string>entity.other.attribute-name.id.css</string>
+					<string>(?x)
+(?:^|(?&lt;=[\s,(};]))         # Follows whitespace, comma, semicolon, or bracket
+(?!
+  [-\w*]+
+  \|
+  (?!
+      [-\[:.*\#a-zA-Z_]    # Make sure there&apos;s a selector to match
+    | [^\x00-\x7F]
+  )
+)
+(
+  (?: [-a-zA-Z_]    | [^\x00-\x7F] )   # First letter
+  (?: [-a-zA-Z0-9_] | [^\x00-\x7F]     # Remainder of identifier
+    | \\(?:[0-9a-fA-F]{1,6}|.)
+  )*
+  |
+  \*     # Universal namespace
+)?
+(\|)     # Namespace separator</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#tag-names</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -794,11 +2874,51 @@
 							<key>name</key>
 							<string>punctuation.definition.entity.css</string>
 						</dict>
+						<key>2</key>
+						<dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
 					</dict>
 					<key>match</key>
-					<string>(:+)(after|before|first-letter|first-line|selection)\b</string>
+					<string>(?x) (?&lt;![@\w-])
+([.\#])
+# Invalid identifier
+(
+  (?:
+    # Starts with ASCII digits, with possible hyphen preceding it
+    -?[0-9]
+    |
+    # Consists of a hyphen only
+    -                                      # Terminated by either:
+    (?= $                                  # - End-of-line
+      | [\s,.\#)\[:{&gt;+~|]               # - Followed by another selector
+      | /\*                               # - Followed by a block comment
+    )
+    |
+    # Name contains unescaped ASCII symbol
+    (?:                                    # Check for acceptable preceding characters
+        [-a-zA-Z_0-9]|[^\x00-\x7F]       # - Valid selector character
+      | \\(?:[0-9a-fA-F]{1,6}|.)         # - Escape sequence
+    )*
+    (?:                                    # Invalid punctuation
+      [!&quot;&apos;%&amp;(*;&lt;?@^`|\]}]                 # - NOTE: We exempt `)` from the list of checked
+      |                                    #   symbols to avoid matching `:not(.invalid)`
+      / (?!\*)                            # - Avoid invalidating the start of a comment
+    )+
+  )
+  # Mark remainder of selector invalid
+  (?: [-a-zA-Z_0-9]|[^\x00-\x7F]         # - Otherwise valid identifier characters
+    | \\(?:[0-9a-fA-F]{1,6}|.)           # - Escape sequence
+  )*
+)</string>
 					<key>name</key>
-					<string>entity.other.attribute-name.pseudo-element.css</string>
+					<string>invalid.illegal.bad-identifier.css</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -807,230 +2927,434 @@
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.entity.css</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(:)((first|last)-child|(first|last|only)-of-type|empty|root|target|first|left|right)\b</string>
-					<key>name</key>
-					<string>entity.other.attribute-name.pseudo-class.css</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(:)(checked|enabled|default|disabled|indeterminate|invalid|optional|required|valid)\b</string>
-					<key>name</key>
-					<string>entity.other.attribute-name.pseudo-class.ui-state.css</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>((:)not)(\()</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.other.attribute-name.pseudo-class.css</string>
 						</dict>
 						<key>2</key>
 						<dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+(\.)                                  # Valid class-name
+(
+  (?: [-a-zA-Z_0-9]|[^\x00-\x7F]     # Valid identifier characters
+    | \\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+  )+
+)                                      # Followed by either:
+(?= $                                  # - End of the line
+  | [\s,.\#)\[:{&gt;+~|]               # - Another selector
+  | /\*                               # - A block comment
+)</string>
+					<key>name</key>
+					<string>entity.other.attribute-name.class.css</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
 							<key>name</key>
 							<string>punctuation.definition.entity.css</string>
 						</dict>
-						<key>3</key>
+						<key>2</key>
+						<dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?x)
+(\#)
+(
+  -?
+  (?![0-9])
+  (?:[-a-zA-Z0-9_]|[^\x00-\x7F]|\\(?:[0-9a-fA-F]{1,6}|.))+
+)
+(?=$|[\s,.\#)\[:{&gt;+~|]|/\*)</string>
+					<key>name</key>
+					<string>entity.other.attribute-name.id.css</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\[</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.function.css</string>
+							<string>punctuation.definition.entity.begin.bracket.square.css</string>
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>\)</string>
+					<string>\]</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.section.function.css</string>
+							<string>punctuation.definition.entity.end.bracket.square.css</string>
 						</dict>
 					</dict>
+					<key>name</key>
+					<string>meta.attribute-selector.css</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#selector</string>
+							<string>#comment-block</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#string</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.ignore-case.css</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?&lt;=[&quot;&apos;\s]|^|\*/)\s*([iI])\s*(?=[\s\]]|/\*|$)</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>string.unquoted.attribute-value.css</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?x)(?&lt;==)\s*((?!/\*)(?:[^\\&quot;&apos;\s\]]|\\.)+)</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>[~|^$*]?=</string>
+							<key>name</key>
+							<string>keyword.operator.pattern.css</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\|</string>
+							<key>name</key>
+							<string>punctuation.separator.css</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>entity.other.namespace-prefix.css</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?x)
+# Qualified namespace prefix
+( -?(?!\d)(?:[\w-]|[^\x00-\x7F]|\\(?:[0-9a-fA-F]{1,6}|.))+
+| \*
+)
+# Lookahead to ensure there&apos;s a valid identifier ahead
+(?=
+  \| (?!\s|=|$|\])
+  (?: -?(?!\d)
+   |   [\\\w-]
+   |   [^\x00-\x7F]
+   )
+)</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>entity.other.attribute-name.css</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#escapes</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>(?x)
+(-?(?!\d)(?&gt;[\w-]|[^\x00-\x7F]|\\(?:[0-9a-fA-F]{1,6}|.))+)
+\s*
+(?=[~|^\]$*=]|/\*)</string>
 						</dict>
 					</array>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.other.attribute-name.pseudo-class.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>constant.numeric.css</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.function.css</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>((:)nth-(?:(?:last-)?child|(?:last-)?of-type))(\()(\-?(?:\d+n?|n)(?:\+\d+)?|even|odd)(\))</string>
+					<key>include</key>
+					<string>#pseudo-classes</string>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
-						</dict>
-					</dict>
+					<key>include</key>
+					<string>#pseudo-elements</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#functional-pseudo-classes</string>
+				</dict>
+				<dict>
 					<key>match</key>
-					<string>(:)(active|hover|link|visited|focus)\b</string>
+					<string>(?x) (?&lt;![@\w-])
+(?=            # Custom element names must:
+  [a-z]        # - start with a lowercase ASCII letter,
+  \w* -       # - contain at least one dash
+)
+(?:
+  (?![A-Z])    # No uppercase ASCII letters are allowed
+  [\w-]       # Allow any other word character or dash
+)+
+(?![(\w-])</string>
 					<key>name</key>
-					<string>entity.other.attribute-name.pseudo-class.css</string>
+					<string>entity.name.tag.custom.css</string>
 				</dict>
+			</array>
+		</dict>
+		<key>string</key>
+		<dict>
+			<key>patterns</key>
+			<array>
 				<dict>
-					<key>captures</key>
+					<key>begin</key>
+					<string>&quot;</string>
+					<key>beginCaptures</key>
 					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.entity.css</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>entity.other.attribute-name.attribute.css</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.operator.css</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>string.unquoted.attribute-value.css</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>string.quoted.double.attribute-value.css</string>
-						</dict>
-						<key>6</key>
+						<key>0</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.begin.css</string>
 						</dict>
-						<key>7</key>
+					</dict>
+					<key>end</key>
+					<string>&quot;|(?&lt;!\\)(?=$|\n)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.end.css</string>
 						</dict>
 					</dict>
-					<key>match</key>
-					<string>(?i)(\[)\s*(-?[_a-z\\[[:^ascii:]]][_a-z0-9\-\\[[:^ascii:]]]*)(?:\s*([~|^$*]?=)\s*(?:(-?[_a-z\\[[:^ascii:]]][_a-z0-9\-\\[[:^ascii:]]]*)|((?&gt;(['"])(?:[^\\]|\\.)*?(\6)))))?\s*(\])</string>
 					<key>name</key>
-					<string>meta.attribute-selector.css</string>
+					<string>string.quoted.double.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?:\G|^)(?=(?:[^\\&quot;]|\\.)+$)</string>
+							<key>end</key>
+							<string>$</string>
+							<key>name</key>
+							<string>invalid.illegal.unclosed.string.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>&apos;</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.begin.css</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>&apos;|(?&lt;!\\)(?=$|\n)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.string.end.css</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>string.quoted.single.css</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(?:\G|^)(?=(?:[^\\&apos;]|\\.)+$)</string>
+							<key>end</key>
+							<string>$</string>
+							<key>name</key>
+							<string>invalid.illegal.unclosed.string.css</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#escapes</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#escapes</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>
-		<key>string-double</key>
+		<key>tag-names</key>
 		<dict>
-			<key>begin</key>
-			<string>"</string>
-			<key>beginCaptures</key>
+			<key>match</key>
+			<string>(?xi) (?&lt;![\w:-])
+(?:
+    # HTML
+    a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|bgsound
+  | big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|command
+  | content|data|datalist|dd|del|details|dfn|dialog|dir|div|dl|dt|element|em|embed|fieldset
+  | figcaption|figure|font|footer|form|frame|frameset|h[1-6]|head|header|hgroup|hr|html|i
+  | iframe|image|img|input|ins|isindex|kbd|keygen|label|legend|li|link|listing|main|map|mark
+  | marquee|math|menu|menuitem|meta|meter|multicol|nav|nextid|nobr|noembed|noframes|noscript
+  | object|ol|optgroup|option|output|p|param|picture|plaintext|pre|progress|q|rb|rp|rt|rtc
+  | ruby|s|samp|script|section|select|shadow|slot|small|source|spacer|span|strike|strong
+  | style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr
+  | track|tt|u|ul|var|video|wbr|xmp
+
+  # SVG
+  | altGlyph|altGlyphDef|altGlyphItem|animate|animateColor|animateMotion|animateTransform
+  | circle|clipPath|color-profile|cursor|defs|desc|discard|ellipse|feBlend|feColorMatrix
+  | feComponentTransfer|feComposite|feConvolveMatrix|feDiffuseLighting|feDisplacementMap
+  | feDistantLight|feDropShadow|feFlood|feFuncA|feFuncB|feFuncG|feFuncR|feGaussianBlur
+  | feImage|feMerge|feMergeNode|feMorphology|feOffset|fePointLight|feSpecularLighting
+  | feSpotLight|feTile|feTurbulence|filter|font-face|font-face-format|font-face-name
+  | font-face-src|font-face-uri|foreignObject|g|glyph|glyphRef|hatch|hatchpath|hkern
+  | line|linearGradient|marker|mask|mesh|meshgradient|meshpatch|meshrow|metadata
+  | missing-glyph|mpath|path|pattern|polygon|polyline|radialGradient|rect|set|solidcolor
+  | stop|svg|switch|symbol|text|textPath|tref|tspan|use|view|vkern
+
+  # MathML
+  | annotation|annotation-xml|maction|maligngroup|malignmark|math|menclose|merror|mfenced
+  | mfrac|mglyph|mi|mlabeledtr|mlongdiv|mmultiscripts|mn|mo|mover|mpadded|mphantom|mroot
+  | mrow|ms|mscarries|mscarry|msgroup|msline|mspace|msqrt|msrow|mstack|mstyle|msub|msubsup
+  | msup|mtable|mtd|mtext|mtr|munder|munderover|semantics
+)
+(?=[+~&gt;\s,.\#|){:\[]|/\*|$)</string>
+			<key>name</key>
+			<string>entity.name.tag.css</string>
+		</dict>
+		<key>unicode-range</key>
+		<dict>
+			<key>captures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.begin.css</string>
+					<string>constant.other.unicode-range.css</string>
+				</dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.dash.unicode-range.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(?&lt;![\w-])[Uu]\+[0-9A-Fa-f?]{1,6}(?:(-)[0-9A-Fa-f]{1,6})?(?![\w-])</string>
+		</dict>
+		<key>url</key>
+		<dict>
+			<key>begin</key>
+			<string>(?i)(?&lt;![\w@-])(url)(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.url.css</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.function.begin.bracket.round.css</string>
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>"</string>
+			<string>\)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.string.end.css</string>
+					<string>punctuation.section.function.end.bracket.round.css</string>
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.quoted.double.css</string>
+			<string>meta.function.url.css</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\.</string>
+					<string>[^&apos;&quot;)\s]+</string>
 					<key>name</key>
-					<string>constant.character.escape.css</string>
+					<string>variable.parameter.url.css</string>
 				</dict>
-			</array>
-		</dict>
-		<key>string-single</key>
-		<dict>
-			<key>begin</key>
-			<string>'</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
 				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.css</string>
+					<key>include</key>
+					<string>#string</string>
 				</dict>
-			</dict>
-			<key>end</key>
-			<string>'</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
 				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.css</string>
+					<key>include</key>
+					<string>#comment-block</string>
 				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.single.css</string>
-			<key>patterns</key>
-			<array>
 				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escape.css</string>
+					<key>include</key>
+					<string>#escapes</string>
 				</dict>
 			</array>
 		</dict>
 	</dict>
-	<key>scopeName</key>
-	<string>source.css</string>
-	<key>uuid</key>
-	<string>69AA0917-B7BB-11D9-A7E2-000D93C8BE28</string>
 </dict>
 </plist>

--- a/Tests/tests.css
+++ b/Tests/tests.css
@@ -255,3 +255,8 @@ garbage
 	font-weight: normal;
 	font-style: italic;
 }
+
+@keyframes fade-in-scale-keys{
+  0% { scale: 0.95; opacity: 0; }
+  100% { scale: 1.0; opacity: 1; }
+}


### PR DESCRIPTION
Includes the latest syntax from https://github.com/microsoft/vscode/blob/main/extensions/css/syntaxes/css.tmLanguage.json

- Converted `css.tmLanguage.json` to `plist`
- Added `@keyframes` to `tests.css` for validation of a rule that was previously not highlighted.